### PR TITLE
Add localStorage persistence for less requests.

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,8 +1,29 @@
 const wikipediaPageCache = {};
 
+
+// New function to handle localStorage
+function getFromLocalStorage(key) {
+  const data = localStorage.getItem(key);
+  if (data !== null) {
+    return JSON.parse(data);
+  }
+  return null;
+}
+
+function saveToLocalStorage(key, value) {
+  localStorage.setItem(key, JSON.stringify(value));
+}
+
 function checkWikipediaPage(twitterHandle) {
   if (wikipediaPageCache.hasOwnProperty(twitterHandle)) {
     return Promise.resolve(wikipediaPageCache[twitterHandle]);
+  }
+
+  // Check if the twitterHandle is in localStorage
+  const localStorageData = getFromLocalStorage(twitterHandle);
+  if (localStorageData !== null) {
+    wikipediaPageCache[twitterHandle] = localStorageData;
+    return Promise.resolve(localStorageData);
   }
 
   const sparqlQuery = `
@@ -18,6 +39,7 @@ function checkWikipediaPage(twitterHandle) {
     .then((data) => {
       const hasWikipediaPage = data.results.bindings.length > 0;
       wikipediaPageCache[twitterHandle] = hasWikipediaPage;
+      saveToLocalStorage(twitterHandle, hasWikipediaPage);
       return hasWikipediaPage;
     })
     .catch((error) => {


### PR DESCRIPTION
First i want o say 10/10 for idea and execution!
I thought it might be a small improvement to add local storage persistence for already verified handles. This will decrease the number of requests and most possibly performance. Though, caching is a hard problem; a page can be deleted and what not. This commit is a rough bare bone implementation, and might need further discussion and improvements before merging.